### PR TITLE
Add INDEXING_SERVICE_URL to catalog-service Environment

### DIFF
--- a/dev/services/docker-compose.yml
+++ b/dev/services/docker-compose.yml
@@ -135,6 +135,7 @@ services:
       - BINARY_CONTENT_DB_PASSWORD=postgres
       - BINARY_CONTENT_URL=http://not-yet-in-use/
       - INDEXING_SERVICE_SOLR_URL=http://solr:8983/solr/
+      - INDEXING_SERVICE_URL=http://indexing-service:8080/
       - INDEXING_SERVICE_SOLR_USERNAME=
       - INDEXING_SERVICE_SOLR_PASSWORD=
       - INDEXING_SYNC=true


### PR DESCRIPTION
- When using the `dev` docker image, the frontend-service always provides
  an error "Failed to Retrieve Catalog Details" although no catalog is
  uploaded initially
- It is because the Indexing Service still calls Default Service and not the
  local one.
- By adding this Environment Variable the indexing service points to the actual
  dev environment

Tested on Debian Jessie 9 Server

Signed-off-by: Shantanoo <shantanoo.desai@gmail.com>